### PR TITLE
Use Git submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Downloaded Dependencies
-/third-party
+third-party/gtest/src
+third-party/gtest/tmp
 # Files for Build System
 /.gradle
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Downloaded Dependencies
-third-party/gtest/src
-third-party/gtest/tmp
+third-party
 # Files for Build System
 /.gradle
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Downloaded Dependencies
-/third-party
+/third-party/BIN
+/third-party/TEMP
 # Files for Build System
 /.gradle
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Downloaded Dependencies
-third-party
+/third-party
 # Files for Build System
 /.gradle
 compile_commands.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party/gtest"]
 	path = third-party/gtest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third-party/googletest"]
-	path = third-party/googletest
-	url = git@github.com:google/googletest.git
 [submodule "third-party/gtest"]
 	path = third-party/gtest
 	url = git@github.com:google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "third-party/googletest"]
+	path = third-party/googletest
+	url = git@github.com:google/googletest.git
+[submodule "third-party/gtest"]
+	path = third-party/gtest
+	url = git@github.com:google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #                   gtest library
 # --------------------------------------------------- #
 ExternalProject_Add(GTEST_PROJECT
+<<<<<<< HEAD
         SOURCE_DIR third-party/gtest
         TMP_DIR third-party/TEMP
         STAMP_DIR third-party/TEMP
         BINARY_DIR third-party/BIN
+=======
+        GIT_REPOSITORY https://github.com/google/googletest.git
+>>>>>>> parent of 136c4fe... add googletest submodule
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest
         CMAKE_ARGS "-DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -DINSTALL_GMOCK=OFF"
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #                   gtest library
 # --------------------------------------------------- #
 ExternalProject_Add(GTEST_PROJECT
-<<<<<<< HEAD
         SOURCE_DIR third-party/gtest
         TMP_DIR third-party/TEMP
         STAMP_DIR third-party/TEMP
         BINARY_DIR third-party/BIN
-=======
-        GIT_REPOSITORY https://github.com/google/googletest.git
->>>>>>> parent of 136c4fe... add googletest submodule
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest
         CMAKE_ARGS "-DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -DINSTALL_GMOCK=OFF"
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # --------------------------------------------------- #
 ExternalProject_Add(GTEST_PROJECT
         SOURCE_DIR third-party/gtest
+        TMP_DIR third-party/TEMP
+        STAMP_DIR third-party/TEMP
+        BINARY_DIR third-party/BIN
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest
         CMAKE_ARGS "-DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -DINSTALL_GMOCK=OFF"
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #                   gtest library
 # --------------------------------------------------- #
 ExternalProject_Add(GTEST_PROJECT
-        GIT_REPOSITORY https://github.com/google/googletest.git
+        SOURCE_DIR third-party/gtest
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest
         CMAKE_ARGS "-DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -DINSTALL_GMOCK=OFF"
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,20 @@ add_library(gtest STATIC IMPORTED)
 add_dependencies(gtest GTEST_PROJECT)
 set_property(TARGET gtest PROPERTY IMPORTED_LOCATION "${GOOGLETEST_BIN}/googlemock/gtest/libgtest.a")
 
+
+# --- submodule management --- #
+
+add_custom_target(InstallSubmodules
+        COMMAND echo Installing submodules...
+        COMMAND git submodule update --init)
+IF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest/.git")
+        add_custom_target(CleanGtest
+        COMMAND echo "Removing old 'gtest' folder..."
+        COMMAND rm -rf third-party/gtest)
+        add_dependencies(InstallSubmodules CleanGtest)
+ENDIF()
+add_dependencies(GTEST_PROJECT InstallSubmodules)
+
 # --------------------------------------------------- #
 #                   build library
 # --------------------------------------------------- #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # --------------------------------------------------- #
 ExternalProject_Add(GTEST_PROJECT
         SOURCE_DIR third-party/gtest
-        TMP_DIR third-party/TEMP
-        STAMP_DIR third-party/TEMP
-        BINARY_DIR third-party/BIN
+        TMP_DIR third-party/TEMP/gtest
+        STAMP_DIR third-party/TEMP/gtest
+        BINARY_DIR third-party/BIN/gtest
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest
         CMAKE_ARGS "-DBUILD_GTEST=ON -DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF -DINSTALL_GMOCK=OFF"
         INSTALL_COMMAND ""
@@ -49,9 +49,8 @@ set_property(TARGET gtest PROPERTY IMPORTED_LOCATION "${GOOGLETEST_BIN}/googlemo
 # --- submodule management --- #
 
 add_custom_target(InstallSubmodules
-        COMMAND echo Installing submodules...
         COMMAND git submodule update --init)
-IF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest/.git")
+IF((NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest/.git") AND EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest")
         add_custom_target(CleanGtest
         COMMAND echo "Removing old 'gtest' folder..."
         COMMAND rm -rf third-party/gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,10 @@ set_property(TARGET gtest PROPERTY IMPORTED_LOCATION "${GOOGLETEST_BIN}/googlemo
 
 # --- submodule management --- #
 
+set(Gtest_path "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest") 
 add_custom_target(InstallSubmodules
         COMMAND git submodule update --init)
-IF((NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest/.git") AND EXISTS "${CMAKE_CURRENT_BINARY_DIR}/third-party/gtest")
+IF(((NOT EXISTS "${Gtest_path}/.git") OR IS_DIRECTORY "${Gtest_path}/.git") AND EXISTS "${Gtest_path}")
         add_custom_target(CleanGtest
         COMMAND echo "Removing old 'gtest' folder..."
         COMMAND rm -rf third-party/gtest)


### PR DESCRIPTION
The new CMake settings use git submodules rather than a `GIT_REPOSITORY` URL to download the googletest files.
Advantages:
- **An internet connection is only needed for the very first run of `make`.** After that, git will take the local copy if there is no connection.
- Submodules are shown in the GitHub repository.
- Any setup for the submodule(s) can be extended in the CMake file.

Everything works else works the same: `cmake .` and `make` are sufficient to automatically clone the submodules (no manual `git submodule update --init` needed).