### PR TITLE
Disable sonar scan for external pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ before_script:
 
 script:
   - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-6 cmake -DCOVERAGE=1 .
-  - build-wrapper-linux-x86-64 --out-dir bw-output make
+  - 'if test $TRAVIS_PULL_REQUEST = false; then build-wrapper-linux-x86-64 --out-dir bw-output make; else make; fi'
   - ./bin/tests
 
 after_success:
   - coveralls --root .  -E ".*CMakeFiles.*" -e test -e third-party -e src-view -e include --gcov-options '\-lp'
-  - sonar-scanner
+  - 'if test $TRAVIS_PULL_REQUEST = false; then sonar-scanner; fi'
 
 before_deploy:
   # tar the header files and the library


### PR DESCRIPTION
Sonarcloud can not be run on external pull requests because Travis disables encrypted environment variables for [those.](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions) 