### PR TITLE
Faster Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ dist: trusty
 sudo: false
 language: cpp
 
+compiler:
+  - clang
+
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
-      - g++-6
-      - clang-5.0
       - cppcheck
   sonarcloud:
     organization: "andrej-sajenko-github"
@@ -23,21 +21,22 @@ cache:
 before_install:
   - pip install --user cpp-coveralls
   - pip install --user cpplint
+  - 'if test $CC = clang; then ln -sf $(which llvm-cov) /home/travis/bin/gcov; fi'
 
 before_script:
-  - cpplint ./src/*.*
-  - cpplint ./include/*/*.*
-  - cpplint ./src-view/*.*
-  - cpplint ./test/*.*
+  - cpplint --quiet ./src/*.*
+  - cpplint --quiet ./include/*/*.*
+  - cpplint --quiet ./src-view/*.*
+  - cpplint --quiet ./test/*.*
   - cppcheck --std=c++11 --error-exitcode=1 --quiet -Iinclude src/ src-view/
 
 script:
-  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-6 cmake -DCOVERAGE=1 .
+  - cmake -DCOVERAGE=1 .
   - 'if test $TRAVIS_PULL_REQUEST = false; then build-wrapper-linux-x86-64 --out-dir bw-output make; else make; fi'
   - ./bin/tests
 
 after_success:
-  - coveralls --root .  -E ".*CMakeFiles.*" -e test -e third-party -e src-view -e include --gcov-options '\-lp'
+  - coveralls --root . --build-root src/ -E ".*CMakeFiles.*" -e test -e third-party -e src-view -e include
   - 'if test $TRAVIS_PULL_REQUEST = false; then sonar-scanner; fi'
 
 before_deploy:

--- a/src/inplacerunner.h
+++ b/src/inplacerunner.h
@@ -2,6 +2,7 @@
 #define SRC_INPLACERUNNER_H_
 
 #include <utility>
+#include <stdexcept>
 
 #define GRADE_ZERO 0
 #define GRADE_ONE 1


### PR DESCRIPTION
(Cherry-picked from `visual` branch.)

By using the built-in `compiler` key in the .travis.yml file, the build is significantly faster. The compiler used is clang-5.0, which supports up to C++17.