### PR TITLE
Fix Choice Dictionary returning wrong values on unitialized fields

### DIFF
--- a/docs/choice-dictionary.md
+++ b/docs/choice-dictionary.md
@@ -10,7 +10,7 @@ A choice dictionary is a bitset containing n elements that supports reading and 
 
 ## Efficiency
 * Time: O(1) (all operations)
-* Space: O(n) bits
+* Space: n+o(n)
 
 ## Example
 

--- a/src/choicedictionary.cpp
+++ b/src/choicedictionary.cpp
@@ -38,9 +38,14 @@ void ChoiceDictionary::insert(unsigned long int index) {
 bool ChoiceDictionary::get(unsigned long int index) {
     unsigned long int primaryWord;
     unsigned long int targetBit;
+    unsigned long int primaryInnerIndex;
 
     unsigned long int primaryIndex = index / (unsigned long int)wordSize;
-    unsigned long int primaryInnerIndex = index % (unsigned long int)wordSize;
+
+    if (!isInitialized(primaryIndex))
+        return 0;
+
+    primaryInnerIndex = index % (unsigned long int)wordSize;
 
     primaryWord = primary[primaryIndex];
     targetBit = 1UL << (wordSize - SHIFT_OFFSET - primaryInnerIndex);

--- a/test/choicedictionary_test.cpp
+++ b/test/choicedictionary_test.cpp
@@ -23,6 +23,13 @@ TEST(ChoiceDictionaryTest, choicedictionary_integrity) {
 
     std::shuffle(set.begin(), set.end(), std::default_random_engine(seed));
 
+    // test zero initialization
+    std::vector<unsigned long int> nonZero;
+    for (unsigned long int i = 0; i < size; i++) {
+        if (c->get(i) == 1) nonZero.push_back(i);
+    }
+    ASSERT_EQ(nonZero.size(), 0);
+
     // insert into Choice Dictionary and test if choice() returns the correct
     c->insert(123UL);
     ASSERT_EQ(c->choice(), 123);


### PR DESCRIPTION
Fix get() operation sometimes returning 1 if used on an index within an unitialized field