### PR TITLE
Fix compilation for g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,11 @@ set(EXECUTABLE_OUTPUT_PATH bin)                                 # generated bina
 set(CMAKE_INCLUDE_PATH include/)
 
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)
-set(WARNING_FLAGS "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wdeprecated")
+set(WARNING_FLAGS "-Wall -Wextra -Wpedantic -Wconversion -Wdeprecated")
+message(STATUS "Compiler: ${CMAKE_CXX_COMPILER_ID}")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(WARNING_FLAGS "${WARNING_FLAGS} -Werror -Wdocumentation")
+endif()
 set(BUILD_FLAGS "-std=c++11 -O3 -fno-builtin -fno-rtti -ffast-math ${WARNING_FLAGS}")
 set(TEST_FLAGS "-std=c++11 -g -O0 -fno-builtin -fno-rtti -ffast-math ${WARNING_FLAGS}")
 

--- a/include/sealib/collection/compactarray.h
+++ b/include/sealib/collection/compactarray.h
@@ -26,7 +26,7 @@ class CompactArray : public Sequence<uint64_t> {
      * For maximum performance, let v be a power of 2 (to avoid access over word
      * boundaries)
      */
-    explicit CompactArray(uint64_t count, uint64_t v = 3);
+    explicit CompactArray(uint64_t size, uint64_t v = 3);
 
     /**
      * Insert a value to the given index.

--- a/include/sealib/collection/sequence.h
+++ b/include/sealib/collection/sequence.h
@@ -5,7 +5,7 @@
 namespace Sealib {
 /**
  * An sequence interface to be used by several classes in this library.
- * @param T the element type that this sequence holds
+ * @tparam T the element type that this sequence holds
  * @author Simon Heuser
  */
 template <class T, class I = uint64_t>

--- a/include/sealib/collection/variantbitset.h
+++ b/include/sealib/collection/variantbitset.h
@@ -22,15 +22,6 @@ namespace Sealib {
  */
 union VariantBitset {
     /**
-     * Creates a bitset of the given size.
-     * @param size Number of bits in the bitset
-     */
-    VariantBitset(uint64_t size) : bit(size) {}
-    VariantBitset(VariantBitset const &p) : bit(p.bit) {}
-    VariantBitset(std::vector<bool> const &v) : bit(v) {}
-    ~VariantBitset() { bit.~vector(); }
-
-    /**
      * Member that allows reading and writing specific bits.
      */
     std::vector<bool> bit;
@@ -43,23 +34,31 @@ union VariantBitset {
      */
     std::vector<uint64_t> word;
 
-    std::vector<bool>::reference operator[](uint64_t i) {
-        return bit[i];
-    }
+    /**
+     * Creates a bitset of the given size.
+     * @param size Number of bits in the bitset
+     */
+    VariantBitset(uint64_t size) : bit(size) {}
+
+    /**
+     * Creates a bitset from the given bit vector.
+     * @param v bit vector to use
+     */
+    VariantBitset(std::vector<bool> &&v) : bit(std::move(v)) {}
+
+    std::vector<bool>::reference operator[](uint64_t i) { return bit[i]; }
     bool operator[](uint64_t i) const { return bit[i]; }
 
     size_t size() const { return bit.size(); }
 
-    uint8_t getBlock(uint64_t i) const {
-        return byte[i];
-    }
-    uint8_t getShiftedBlock(uint64_t i) const {
-        uint8_t len = 32;
-        uint8_t b1 = bit[i/len];
-        uint8_t b2 = bit[(i+len-1)/len];
-        uint8_t bitIdx = static_cast<uint8_t>(i % len);
-        return static_cast<uint8_t>((b1 >> bitIdx) | (b2 << (len - bitIdx)));
-    }
+    uint8_t getBlock(uint64_t i) const { return byte[i]; }
+    uint8_t getShiftedBlock(uint64_t i) const;
+
+    VariantBitset(VariantBitset const &);
+    VariantBitset(VariantBitset &&);
+    VariantBitset &operator=(VariantBitset const &);
+    VariantBitset &operator=(VariantBitset &&);
+    ~VariantBitset();
 };
 }  // namespace Sealib
 #endif  // SEALIB_COLLECTION_VARIANTBITSET_H_

--- a/include/sealib/dictionary/choicedictionary.h
+++ b/include/sealib/dictionary/choicedictionary.h
@@ -21,7 +21,7 @@ class ChoiceDictionary {
  public:
     /**
      * Creates choice dictionary with given size
-     * @param length Length of the choice dictionary
+     * @param size Length of the choice dictionary
      */
     explicit ChoiceDictionary(uint64_t size);
 

--- a/include/sealib/dictionary/rankselect.h
+++ b/include/sealib/dictionary/rankselect.h
@@ -18,7 +18,7 @@ class RankSelect {
 
  public:
     /**
-     * @param Sealib::Bitset used for RankSelect
+     * @param bitset Sealib::Bitset used for RankSelect
      */
     explicit RankSelect(const Bitset<uint8_t> &bitset);
     explicit RankSelect(Bitset<uint8_t> &&bitset);

--- a/include/sealib/dictionary/sharedrankselect.h
+++ b/include/sealib/dictionary/sharedrankselect.h
@@ -19,7 +19,7 @@ class SharedRankSelect {
 
  public:
     /**
-     * @param shared_ptr managing the Sealib::Bitset used for RankSelect
+     * @param bitset shared_ptr managing the Sealib::Bitset used for RankSelect
      */
     explicit SharedRankSelect(std::shared_ptr<const Bitset<uint8_t> > bitset);
     SharedRankSelect();

--- a/include/sealib/dictionary/sharedrankstructure.h
+++ b/include/sealib/dictionary/sharedrankstructure.h
@@ -35,7 +35,7 @@ class SharedRankStructure {
     uint64_t rank(uint64_t k) const;
 
     /**
-     * @param shared_ptr managing the Sealib::Bitset used for Rank
+     * @param bitset shared_ptr managing the Sealib::Bitset used for Rank
      */
     explicit SharedRankStructure(std::shared_ptr<const Sealib::Bitset<uint8_t> > bitset);
 

--- a/include/sealib/graph/compactgraph.h
+++ b/include/sealib/graph/compactgraph.h
@@ -22,7 +22,7 @@ class CompactGraph : public Graph {
 	public:
 		/**
 		 * Creates a compactgraph object out of a pointer to an uint64_t array
-		 * @param A pointer to a graph array in standard representation
+		 * @param _A pointer to a graph array in standard representation
 		 */
 		explicit CompactGraph(uint64_t _A[]);
 

--- a/include/sealib/graph/directedgraph.h
+++ b/include/sealib/graph/directedgraph.h
@@ -16,20 +16,20 @@ class DirectedGraph : public Graph {
  public:
     /**
      * Creates a new graph object with the nodes provided by the nodes_ vector
-     * @param nodes_ vector of nodes
+     * @param _nodes vector of nodes
      */
     explicit DirectedGraph(std::vector<SimpleNode> _nodes)
         : nodes(std::move(_nodes)) {}
 
     /**
      * Created a graph with the specified order and without any edges.
-     * @param order - order of the graph
+     * @param order order of the graph
      */
     explicit DirectedGraph(uint64_t order) : nodes(order) {}
 
     /**
      * Adds a new node to the graph
-     * @param const ref of node to be added
+     * @param node node to be added
      */
     void addNode(SimpleNode const &node) { nodes.emplace_back(node); }
 

--- a/include/sealib/graph/undirectedgraph.h
+++ b/include/sealib/graph/undirectedgraph.h
@@ -18,7 +18,7 @@ class UndirectedGraph : public Graph {
  public:
     /**
      * Creates a new graph object from a given node vector.
-     * @param nodes_ vector of nodes
+     * @param _nodes vector of nodes
      */
     explicit UndirectedGraph(std::vector<ExtendedNode> _nodes) : nodes(std::move(_nodes)) {}
 
@@ -30,7 +30,7 @@ class UndirectedGraph : public Graph {
 
     /**
      * Adds a new node to the graph
-     * @param const ref of node to be added
+     * @param node node to be added
      */
     void addNode(ExtendedNode const &node) { nodes.emplace_back(node); }
 

--- a/include/sealib/iterator/bfs.h
+++ b/include/sealib/iterator/bfs.h
@@ -34,9 +34,9 @@ class BFS : Iterator<std::pair<uint64_t, uint64_t>> {
     * @param preprocess to be executed before processing a node u
     * @param preexplore to be executed before exploring an edge (u,v)
     */
-    BFS(Graph const &g, Consumer pp, BiConsumer pe);
+    BFS(Graph const &g, Consumer preprocess, BiConsumer preexplore);
 
-    BFS(Graph const &g, CompactArray color, Consumer pp, BiConsumer pe);
+    BFS(Graph const &g, CompactArray color, Consumer preprocess, BiConsumer preexplore);
 
     /**
      * Initialize or reset the BFS to the beginning.

--- a/include/sealib/iterator/choicedictionaryiterator.h
+++ b/include/sealib/iterator/choicedictionaryiterator.h
@@ -15,16 +15,13 @@ namespace Sealib {
  */
 class ChoiceDictionaryIterator : Iterator<uint64_t> {
  private:
-    /**
-     * @param primaryWord Value of the currently used word in primary.
-     * @param secondaryWord Value of the currently used word in secondary.
-     * @param primaryIndex Index of the currently used word in primary.
-     * @param secondaryIndex Index of the currently used word in secondary.
-     * @param pointer currently used pointer Position.
-     * @param choicedictionary Pointer to an existing choice dictionary.
-     */
-    uint64_t primaryWord, secondaryWord, pointer, primaryIndex, secondaryIndex;
-    ChoiceDictionary const &choicedictionary;
+    uint64_t primaryWord,  ///< Value of the currently used word in primary
+        secondaryWord,     ///< Value of the currently used word in secondary
+        pointer,           ///< currently used pointer Position
+        primaryIndex,      ///< Index of the currently used word in primary
+        secondaryIndex;    ///< Index of the currently used word in secondary
+    ChoiceDictionary const
+        &choicedictionary;  ///< Pointer to an existing choice dictionary
 
     bool hasNextSecondary();
 
@@ -35,7 +32,7 @@ class ChoiceDictionaryIterator : Iterator<uint64_t> {
  public:
     /**
      * Creates an Iterator for a choice dictionary.
-     * @param _choicedictionary Pointer to an existing choice dictionary.
+     * @param choicedictionary Pointer to an existing choice dictionary.
      */
     explicit ChoiceDictionaryIterator(ChoiceDictionary const &choicedictionary);
 

--- a/include/sealib/iterator/iterator.h
+++ b/include/sealib/iterator/iterator.h
@@ -5,7 +5,7 @@
 namespace Sealib {
 /**
  * An iterator interface to be used by several classes in this library.
- * @param T the element type that this iterator iterates over
+ * @tparam T the element type that this iterator iterates over
  * @author Simon Heuser
  */
 template <class T>

--- a/include/sealib/legacy.h
+++ b/include/sealib/legacy.h
@@ -49,7 +49,7 @@ int Sealib_ChoiceDictionary_get(void *self, uint64_t index);
 /**
  * Get index of a random set bit.
  * @param self Choice dictionary instance
- * @param Index of a set bit
+ * @return Index of a set bit
  */
 uint64_t Sealib_ChoiceDictionary_choice(void *self);
 
@@ -101,7 +101,7 @@ int Sealib_Bitset_get(void *self, uint64_t index);
 
 /**
  * Create a new rank-select structure
- * @param size Number of entries
+ * @param bitset bitset to use
  * @return Pointer to the rank-select structure
  */
 void *Sealib_RankSelect_new(void *bitset);

--- a/include/sealib/trackingallocator.h
+++ b/include/sealib/trackingallocator.h
@@ -30,7 +30,7 @@ class TrackingAllocator {
     /**
      * Needed to rebind a TrackingAllocator<U> to TrackingAllocator<U'>,
      * if needed by the container using TrackingAllocator.
-     * @tparam U
+     * @tparam U element type
      */
     template<class U>
     struct rebind {
@@ -42,12 +42,10 @@ class TrackingAllocator {
     /**
      * Needed to rebind a TrackingAllocator<U> to TrackingAllocator<U'>,
      * if needed by the container using TrackingAllocator.
-     * @tparam U
+     * @tparam U element type
      */
     template<class U>
-    TrackingAllocator(const TrackingAllocator<U> &other) {
-        (void) other;
-    }
+    TrackingAllocator(const TrackingAllocator<U> &) {}
 
     /**
      * Allocates numObjects *sizeof(T) * bytes space and writes that

--- a/src-view/sealibvisual/examples.h
+++ b/src-view/sealibvisual/examples.h
@@ -30,12 +30,12 @@ class VisualBFS {
  public:
     /**
      * Creates a new BFS visualisation.
-     * @param Graph Graph to use
-     * @param CompactArray Color array to use
+     * @param g Graph to use
+     * @param c CompactArray Color array to use
      * @param filename Output file name
      * @param mode Output mode: "standalone" or "beamer"
      */
-    VisualBFS(Sealib::Graph const &, Sealib::CompactArray,
+    VisualBFS(Sealib::Graph const &g, Sealib::CompactArray c,
               std::string filename = "example.tex",
               std::string mode = "standalone");
     /**
@@ -57,12 +57,12 @@ class VisualDFS : Sealib::ExtendedSegmentStack, Sealib::DFS {
  public:
     /**
      * Creates a new DFS visualisation.
-     * @param Graph Graph to use
-     * @param CompactArray Color array to use
+     * @param g Graph Graph to use
+     * @param c CompactArray Color array to use
      * @param filename Output file name
      * @param mode Output mode: "standalone" or "beamer"
      */
-    VisualDFS(Sealib::Graph const &, Sealib::CompactArray *,
+    VisualDFS(Sealib::Graph const &g, Sealib::CompactArray *c,
               std::string filename = "example.tex",
               std::string mode = "standalone");
     /**

--- a/src-view/sealibvisual/tikzdocument.h
+++ b/src-view/sealibvisual/tikzdocument.h
@@ -22,7 +22,7 @@ class TikzDocument {
      * @param _gdLibraries Tikz graph drawing libraries to use (generates
      * \usegdlibrary statement)
      * @param _lualatex Compile with LuaLaTex? (needed for graph layouts)
-     * @param mode output format to generate ("standalone": a freestanding
+     * @param _mode output format to generate ("standalone": a freestanding
      * (lua)latex document, to animate the resulting document, use 'convert' on
      * the PDF; "beamer": (lua)latex code to include in a beamer presentation)
      */

--- a/src/collection/variantbitset.cpp
+++ b/src/collection/variantbitset.cpp
@@ -1,0 +1,29 @@
+#include "sealib/collection/variantbitset.h"
+
+namespace Sealib {
+
+uint8_t VariantBitset::getShiftedBlock(uint64_t i) const {
+    uint8_t len = 32;
+    uint8_t b1 = bit[i / len];
+    uint8_t b2 = bit[(i + len - 1) / len];
+    uint8_t bitIdx = static_cast<uint8_t>(i % len);
+    return static_cast<uint8_t>((b1 >> bitIdx) | (b2 << (len - bitIdx)));
+}
+
+VariantBitset::VariantBitset(VariantBitset const &p) : bit(p.bit) {}
+
+VariantBitset::VariantBitset(VariantBitset &&p) : bit(std::move(p.bit)) {}
+
+VariantBitset &VariantBitset::operator=(VariantBitset const &p) {
+    bit = p.bit;
+    return *this;
+}
+
+VariantBitset &VariantBitset::operator=(VariantBitset &&p) {
+    bit = std::move(p.bit);
+    return *this;
+}
+
+VariantBitset::~VariantBitset() { bit.~vector(); }
+
+}  // namespace Sealib

--- a/src/rankselect/localranktable.h
+++ b/src/rankselect/localranktable.h
@@ -23,8 +23,8 @@ class LocalRankTable {
     /**
     * Values are stored in a lookup table.
     * The lookup table is a static instance in this function that is initialized on the first call.
-    * @param segment - unsinged char representing a bit vector of size 8
-    * @param index in the segment
+    * @param segment unsigned char representing a bit vector of size 8
+    * @param i index in the segment
     * @return bits set up to and including the i-th bit
     */
     static uint8_t getLocalRank(uint8_t segment, uint8_t i);

--- a/src/rankselect/localselecttable.h
+++ b/src/rankselect/localselecttable.h
@@ -22,8 +22,8 @@ class LocalSelectTable {
     /**
     * Values are stored in a lookup table.
     * The lookup table is a static instance in this function that is initialized on the first call.
-    * @param segment - unsinged char representing a bit vector of size 8
-    * @param i-th set bit to be selected
+    * @param segment unsigned char representing a bit vector of size 8
+    * @param i set bit to be selected
     * @return index of the i-th bit, or (unsinged char) - 1 if there is none
     */
     static uint8_t getLocalSelect(uint8_t segment, uint8_t i);

--- a/src/trail/doublelinkedlist.h
+++ b/src/trail/doublelinkedlist.h
@@ -19,7 +19,7 @@ class DoubleLinkedList {
      */
     virtual uint64_t get() = 0;
     /**
-    * @param element to be removed
+    * @param idx element to be removed
     * @return the removed element, or error value if the element was not present.
     */
     virtual uint64_t remove(uint64_t idx) = 0;

--- a/src/trail/largedoublelinkedlist.h
+++ b/src/trail/largedoublelinkedlist.h
@@ -23,7 +23,7 @@ class LargeDoubleLinkedList : public DoubleLinkedList {
     uint64_t get() override;
 
     /**
-    * @param element to be removed
+    * @param idx element to be removed
     * @return the removed element, or (uint64_t)-1 if the element was not present.
     */
     uint64_t remove(uint64_t idx) override;

--- a/src/trail/naiveeulertrail.h
+++ b/src/trail/naiveeulertrail.h
@@ -13,7 +13,6 @@ namespace Sealib {
  * Space efficient Euler Trail class. Initialized with an undirected graph object G_0,
  * creates a set of euler partitions for G_0 during construction.
  * Uses O(n+m) time for the construction and occupies O(n) space after construction.
- * @tparam TrailStructureType
  */
 class NaiveEulerTrail {
  private:

--- a/src/trail/simpletrailstructure.h
+++ b/src/trail/simpletrailstructure.h
@@ -68,8 +68,8 @@ class SimpleTrailStructure {
     /**
      * Leaves the node, gets arbitrary element from unused,
      * moves it to InAndOut and returns it.
-     * If the TrailStructure is black, it returns uint64_t max value.
-     * @return 
+     * @return arbitrary unused element; if the TrailStructure is black, returns
+     * uint64_t max value.
      */
     uint64_t leave();
 
@@ -84,9 +84,9 @@ class SimpleTrailStructure {
     bool hasStartingArc() const;
 
     /**
-     * Enters the node at the specified edge/arc, and if there is an unused arc left, 
-     * leaves it at the next arc and matches the entering and exiting arcs.
-     * Otherwise the entering arc is left unmatched.
+     * Enters the node at the specified edge/arc, and if there is an unused arc
+     * left, leaves it at the next arc and matches the entering and exiting
+     * arcs. Otherwise the entering arc is left unmatched.
      * @param i arc to enter
      * @return arc that was left, or unsiged int max value if no arc.
      */
@@ -95,8 +95,8 @@ class SimpleTrailStructure {
     /**
      * Gets the match for a given matched arc.
      * The inAndOut bit array is interpreted as a dyckword.
-     * @param idx 
-     * @return 
+     * @param idx arc
+     * @return match
      */
     uint64_t getMatched(uint64_t idx) const;
 

--- a/src/trail/smalldoublelinkedlist.h
+++ b/src/trail/smalldoublelinkedlist.h
@@ -23,7 +23,7 @@ class SmallDoubleLinkedList : public DoubleLinkedList {
     uint64_t get() override;
 
      /**
-     * @param element to be removed
+     * @param idx element to be removed
      * @return the removed element, or (uint8_t)-1 if the element was not present.
      */
     uint64_t remove(uint64_t idx) override;

--- a/src/trail/trailstructure.h
+++ b/src/trail/trailstructure.h
@@ -3,9 +3,9 @@
 
 #include <sealib/dictionary/rankselect.h>
 #include <sealib/dictionary/simplerankselect.h>
+#include <vector>
 #include "../dyck/dyckmatchingstructure.h"
 #include "doublelinkedlist.h"
-#include <vector>
 
 namespace Sealib {
 class DoubleLinkedList;
@@ -92,15 +92,15 @@ class TrailStructure {
     /**
      * Leaves the node, gets arbitrary element from unused,
      * moves it to InAndOut and returns it.
-     * If the TrailStructure is black, it returns uint64_t max value.
-     * @return
+     * @return arbitrary unused element; if the TrailStructure is black,
+     * returns uint64_t max value.
      */
     uint64_t leave();
 
     /**
-     * Enters the node at the specified edge/arc, and if there is an unused arc left,
-     * leaves it at the next arc and matches the entering and exiting arcs.
-     * Otherwise the entering arc is left unmatched.
+     * Enters the node at the specified edge/arc, and if there is an unused arc
+     * left, leaves it at the next arc and matches the entering and exiting
+     * arcs. Otherwise the entering arc is left unmatched.
      * @param i arc to enter
      * @return arc that was left, or unsiged int max value if no arc.
      */
@@ -146,15 +146,15 @@ class TrailStructure {
     /**
      * Gets the match for a given matched arc.
      * The inAndOut bit array is interpreted as a dyckword.
-     * @param idx
-     * @return
+     * @param idx arc
+     * @return match
      */
     uint64_t getMatched(uint64_t idx) const;
 
     /**
      * Used for debugging
-     * @param idx
-     * @return
+     * @param idx arc
+     * @return match
      */
     uint64_t getMatchedNaive(uint64_t idx);
 };


### PR DESCRIPTION
- `g++` can now compile the library without errors, but not necessarily without warnings.
- added documentation warnings (activated when using clang)